### PR TITLE
Dynamic type and severity

### DIFF
--- a/src/main/java/com/adaptris/labs/verify/CreateVerifyReport.java
+++ b/src/main/java/com/adaptris/labs/verify/CreateVerifyReport.java
@@ -28,14 +28,10 @@ public class CreateVerifyReport {
   private static final String ENGINE_ID_ARG = "engineId";
   private static final String RULE_ID_PREFIX_ARG = "ruleIdPrefix";
   private static final String LOCATION_FILE_PATH_ARG = "locationFilePath";
-  private static final String INC_ONLY_LINES_STARTING = "includeOnlyLinesStarting";
-  private static final String REMOVE_LINE_STARTING_STRING = "removeIncludeOnlyLineFilter";
 
   private static final String ENGINE_ID_DEFAULT = "interlokVerify";
   private static final String RULE_ID_PREFIX_DEFAULT = "rule";
   private static final String LOCATION_FILE_PATH_DEFAULT = "./src/main/interlok/config/adapter.xml";
-  private static final String INC_ONLY_LINES_STARTING_DEFAULT = "";
-  private static final String REMOVE_LINE_STARTING_STRING_DEFAULT = "true";
 
   CreateVerifyReport(){
     options = new Options();
@@ -46,8 +42,6 @@ public class CreateVerifyReport {
     options.addOption("e", ENGINE_ID_ARG, true, String.format("The engine id (default: %s)", ENGINE_ID_DEFAULT));
     options.addOption("r", RULE_ID_PREFIX_ARG, true, String.format("The rule id prefix (default: %s)", RULE_ID_PREFIX_DEFAULT));
     options.addOption("l", LOCATION_FILE_PATH_ARG, true, String.format("The location file path (default: %s)", LOCATION_FILE_PATH_DEFAULT));
-    options.addOption("i", INC_ONLY_LINES_STARTING, true, String.format("Include only lines starting with input (default: %s)", INC_ONLY_LINES_STARTING_DEFAULT));
-    options.addOption("s", REMOVE_LINE_STARTING_STRING, true, String.format("Remove include only line filter (default: %s)", REMOVE_LINE_STARTING_STRING_DEFAULT));
 
     helpOnlyOptions = new Options();
     helpOnlyOptions.addOption(help);
@@ -82,9 +76,7 @@ public class CreateVerifyReport {
         line.getOptionValue(RULE_ID_PREFIX_ARG, RULE_ID_PREFIX_DEFAULT),
         line.getOptionValue(LOCATION_FILE_PATH_ARG, LOCATION_FILE_PATH_DEFAULT),
         line.getOptionValue(REPORT_FILE_ARG),
-        line.getOptionValue(OUTPUT_FILE_ARG),
-        line.getOptionValue(INC_ONLY_LINES_STARTING, INC_ONLY_LINES_STARTING_DEFAULT),
-        Boolean.parseBoolean(line.getOptionValue(REMOVE_LINE_STARTING_STRING, REMOVE_LINE_STARTING_STRING_DEFAULT))
+        line.getOptionValue(OUTPUT_FILE_ARG)
       );
     } catch (ParseException e) {
       usage();
@@ -98,17 +90,15 @@ public class CreateVerifyReport {
       int i = 1;
       while (scanner.hasNextLine()) {
         String line = scanner.nextLine();
-        if (line.startsWith(argumentWrapper.getIncludeOnlyLinesStarting())) {
-          issueList.add(new Issue(
-            argumentWrapper.getEngineId(),
-            String.format("%s%s", argumentWrapper.getRuleIdPrefix(), i++),
-            Severity.INFO,
-            Type.CODE_SMELL,
-            new Location(
-              argumentWrapper.getRemoveIncludeOnlyLineFilter() ? line.substring(argumentWrapper.getIncludeOnlyLinesStarting().length()) : line,
-              argumentWrapper.getLocationFilePath())
-          ));
-        }
+        issueList.add(new Issue(
+          argumentWrapper.getEngineId(),
+          String.format("%s%s", argumentWrapper.getRuleIdPrefix(), i++),
+          Severity.INFO,
+          Type.CODE_SMELL,
+          new Location(
+            line,
+            argumentWrapper.getLocationFilePath())
+        ));
       }
     }
     return new Issues(issueList);
@@ -141,12 +131,6 @@ public class CreateVerifyReport {
 
     @Getter
     private final String outputFile;
-
-    @Getter
-    private final String includeOnlyLinesStarting;
-
-    @Getter
-    private final boolean removeIncludeOnlyLineFilter;
   }
 
 }

--- a/src/test/java/com/adaptris/labs/verify/CreateVerifyReportTest.java
+++ b/src/test/java/com/adaptris/labs/verify/CreateVerifyReportTest.java
@@ -29,7 +29,7 @@ class CreateVerifyReportTest {
         "./adapter.xml",
         "report.txt",
         "report.json"),
-      "something\nsomething2");
+      "CODE_SMELL,INFO,something\nCODE_SMELL,INFO,something2");
     assertEquals(2, issues.getIssues().size());
     Issue issue1 = issues.getIssues().get(0);
     assertEquals("engineId", issue1.getEngineId());
@@ -45,6 +45,27 @@ class CreateVerifyReportTest {
     assertEquals(Severity.INFO, issue2.getSeverity());
     assertEquals("./adapter.xml", issue2.getPrimaryLocation().getFilePath());
     assertEquals("something2", issue2.getPrimaryLocation().getMessage());
+  }
+
+  @Test
+  void createIssuesInvalidInput(){
+    CreateVerifyReport createVerifyReport = new CreateVerifyReport();
+    Issues issues = createVerifyReport.createIssues(
+      new CreateVerifyReport.ArgumentWrapper(
+        "engineId",
+        "rule",
+        "./adapter.xml",
+        "report.txt",
+        "report.json"),
+      "CODE_SMELL,INFO,something\nINVALID,INFO,something2");
+    assertEquals(1, issues.getIssues().size());
+    Issue issue1 = issues.getIssues().get(0);
+    assertEquals("engineId", issue1.getEngineId());
+    assertEquals("rule1", issue1.getRuleId());
+    assertEquals(Type.CODE_SMELL, issue1.getType());
+    assertEquals(Severity.INFO, issue1.getSeverity());
+    assertEquals("./adapter.xml", issue1.getPrimaryLocation().getFilePath());
+    assertEquals("something", issue1.getPrimaryLocation().getMessage());
   }
 
   @Test
@@ -182,7 +203,7 @@ class CreateVerifyReportTest {
     File tmpDir = createTempDirectory();
     File outputFile = new File(tmpDir, "out.json");
     File reportFile = new File(tmpDir, "report.txt");
-    FileUtils.writeStringToFile(reportFile, "something\nsomething else", StandardCharsets.UTF_8);
+    FileUtils.writeStringToFile(reportFile, "CODE_SMELL,INFO,something\nCODE_SMELL,INFO,something else", StandardCharsets.UTF_8);
     List<String> args = new ArrayList<>();
     args.add("--reportFile");
     args.add(reportFile.getAbsolutePath());

--- a/src/test/java/com/adaptris/labs/verify/CreateVerifyReportTest.java
+++ b/src/test/java/com/adaptris/labs/verify/CreateVerifyReportTest.java
@@ -28,9 +28,7 @@ class CreateVerifyReportTest {
         "rule",
         "./adapter.xml",
         "report.txt",
-        "report.json",
-        "",
-        true),
+        "report.json"),
       "something\nsomething2");
     assertEquals(2, issues.getIssues().size());
     Issue issue1 = issues.getIssues().get(0);
@@ -47,52 +45,6 @@ class CreateVerifyReportTest {
     assertEquals(Severity.INFO, issue2.getSeverity());
     assertEquals("./adapter.xml", issue2.getPrimaryLocation().getFilePath());
     assertEquals("something2", issue2.getPrimaryLocation().getMessage());
-  }
-
-  @Test
-  void createIssuesWithFilter(){
-    CreateVerifyReport createVerifyReport = new CreateVerifyReport();
-    Issues issues = createVerifyReport.createIssues(
-      new CreateVerifyReport.ArgumentWrapper(
-        "engineId",
-        "rule",
-        "./adapter.xml",
-        "report.txt",
-        "report.json",
-        "VERIFY_REPORT: ",
-        false),
-      "something\nVERIFY_REPORT: something2");
-    assertEquals(1, issues.getIssues().size());
-    Issue issue = issues.getIssues().get(0);
-    assertEquals("engineId", issue.getEngineId());
-    assertEquals("rule1", issue.getRuleId());
-    assertEquals(Type.CODE_SMELL, issue.getType());
-    assertEquals(Severity.INFO, issue.getSeverity());
-    assertEquals("./adapter.xml", issue.getPrimaryLocation().getFilePath());
-    assertEquals("VERIFY_REPORT: something2", issue.getPrimaryLocation().getMessage());
-  }
-
-  @Test
-  void createIssuesWithFilterRemoveLineFilter(){
-    CreateVerifyReport createVerifyReport = new CreateVerifyReport();
-    Issues issues = createVerifyReport.createIssues(
-      new CreateVerifyReport.ArgumentWrapper(
-        "engineId",
-        "rule",
-        "./adapter.xml",
-        "report.txt",
-        "report.json",
-        "VERIFY_REPORT: ",
-        true),
-      "something\nVERIFY_REPORT: something2");
-    assertEquals(1, issues.getIssues().size());
-    Issue issue = issues.getIssues().get(0);
-    assertEquals("engineId", issue.getEngineId());
-    assertEquals("rule1", issue.getRuleId());
-    assertEquals(Type.CODE_SMELL, issue.getType());
-    assertEquals(Severity.INFO, issue.getSeverity());
-    assertEquals("./adapter.xml", issue.getPrimaryLocation().getFilePath());
-    assertEquals("something2", issue.getPrimaryLocation().getMessage());
   }
 
   @Test


### PR DESCRIPTION
## Motivation

Allow for dynamic type and severity 

## Modification

**Breaking change**

Reverted unneeded filtering change.

Reports now expected to be in the following format:

```csv
CODE_SMELL,INFO,[UploadOperation] uses [bucket-name], use [bucket] instead
CODE_SMELL,INFO,[UploadOperation] uses [key], use the alternative string-based expression instead
```

## Result

Reports type and severity can now be changed

## Testing

To get help:
```
./gradlew run --args="--help"
```
To generate report:
```
mkdir build
echo "CODE_SMELL,INFO,something" > ./build/report.txt
.\gradlew run --args="--reportFile ./build/report.txt --outputFile ./build/out.json"
```
